### PR TITLE
✨Add example of matrix definition generated by a different job

### DIFF
--- a/.github/workflows/create_matrix-multistage.yml
+++ b/.github/workflows/create_matrix-multistage.yml
@@ -41,7 +41,7 @@ jobs:
     needs: [create_matrix]
     strategy:
       matrix:
-        matrix: ${{fromJson(needs.create_matrix.outputs.matrix)}}
+        ${{fromJson(needs.create_matrix.outputs.matrix)}}
         # python-version: [3.8, 3.9, "3.10"]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/create_matrix-multistage.yml
+++ b/.github/workflows/create_matrix-multistage.yml
@@ -21,8 +21,23 @@ jobs:
           print(matrix)
           print(f"::set-output name=matrix::{json.dumps(matrix)}")
 
+  show_matrix:
+    name: Show matrix
+    needs: [create_matrix]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install json2yaml
+        run: |
+          sudo npm install -g json2yaml
+      - name: Check matrix definition
+        run: |
+          matrix='${{ needs.create_matrix.outputs.matrix }}'
+          echo $matrix
+          echo $matrix | jq .
+          echo $matrix | json2yaml
+
   run_tests:
-    name: Create run matrix
+    name: Run tests
     needs: [create_matrix]
     strategy:
       matrix:

--- a/.github/workflows/create_matrix-multistage.yml
+++ b/.github/workflows/create_matrix-multistage.yml
@@ -1,0 +1,39 @@
+name: Create matrix multistage
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  create_matrix:
+    name: Create run matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.create-matrix.outputs.matrix }}
+    steps:
+      - name: Create Matrix
+        id: create-matrix
+        shell: python
+        run: |
+          import json
+          matrix = {"python-version": ["3.8", "3.9", "3.10"]}
+          print(matrix)
+          print(f"::set-output name=matrix::{json.dumps(matrix)}")
+
+  run_tests:
+    name: Create run matrix
+    needs: [create_matrix]
+    strategy:
+      matrix:
+        matrix: ${{fromJson(needs.create_matrix.outputs.matrix)}}
+        # python-version: [3.8, 3.9, "3.10"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run tests
+        run: python --version


### PR DESCRIPTION
This can for example used for github actions that support multiple inputs.
For example, the [pyglotaran-examples action](https://github.com/glotaran/pyglotaran-examples) can run multiple examples to run them all a user needs to define the list of example names in the matrix which could easily get out of sync.
Thus having the action generate the list of all possible examples would allow for it to be self-managed.